### PR TITLE
The correction solved one error in atlas only to present that "v." is…

### DIFF
--- a/policytool/atlas.py
+++ b/policytool/atlas.py
@@ -40,7 +40,7 @@ class Client:
             criteria = {
                 'attributeName': 'qualifiedName',
                 'operator': 'STARTSWITH' if n == 0 else 'CONTAINS',
-                'attributeValue': v + "."
+                'attributeValue': v
             }
             n += 1
             criterion.append(criteria)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class PyTest(TestCommand):
 
 setup(
     name="cobra-policytool",
-    version="1.1.5",
+    version="1.1.6",
     author="Magnus Runesson",
     author_email="Magnus.Runesson@svenskaspel.se",
     description="Tool for manage Hadoop access using Apache Atlas and Ranger.",


### PR DESCRIPTION
… not allowed in any of the entity searches.